### PR TITLE
moved invalideLater into "still alive if" to avoid execution of react…

### DIFF
--- a/sync-async-callr.R
+++ b/sync-async-callr.R
@@ -3,7 +3,7 @@ library(callr)
 
 # functions
 
-long_job <- function() { 
+long_job <- function() {
   Sys.sleep(10)
   return(TRUE)
 }
@@ -27,7 +27,7 @@ sync_srv <- function(input, output, session) {
     long_job()
     return("Sync job completed")
   })
-  
+
   output$did_it_work <- renderText({
     long_run()
   })
@@ -55,18 +55,18 @@ background_srv <-
       )
       return(x)
     })
-    
+
     check <- reactive({
-      invalidateLater(millis = 1000, session = session)
-      
       if (long_run()$is_alive()) {
+        invalidateLater(millis = 1000, session = session)
+
         x <- "Job running in background"
       } else {
         x <- "Async job in background completed"
       }
       return(x)
     })
-    
+
     output$did_it_work <- renderText({
       check()
     })
@@ -75,11 +75,11 @@ background_srv <-
 
 # Define UI for application that draws a histogram
 ui <- fluidPage(
-  
+
   # Application title
   titlePanel("Old Faithful Geyser Data"),
-  
-  # Sidebar with a slider input for number of bins 
+
+  # Sidebar with a slider input for number of bins
   sidebarLayout(
     sidebarPanel(
       sliderInput("bins",
@@ -92,7 +92,7 @@ ui <- fluidPage(
       tags$hr(),
       background_ui("bg")
     ),
-    
+
     # Show a plot of the generated distribution
     mainPanel(
       plotOutput("distPlot")
@@ -102,19 +102,19 @@ ui <- fluidPage(
 
 # Define server logic required to draw a histogram
 server <- function(input, output) {
-  
+
   output$distPlot <- renderPlot({
     # generate bins based on input$bins from ui.R
     x    <- faithful[, 2]
     bins <- seq(min(x), max(x), length.out = input$bins + 1)
-    
+
     # draw the histogram with the specified number of bins
     hist(x, breaks = bins, col = 'darkgray', border = 'white')
   })
-  
+
   callModule(sync_srv, id = "sync")
   callModule(background_srv, id = "bg")
 }
 
-# Run the application 
+# Run the application
 shinyApp(ui = ui, server = server)


### PR DESCRIPTION
…ive event after async job finished

First of all, nice work. I prefer this solution to future/promises and not only because of the user side async.

Reason for this pr:
In one of my apps, I noticed some weird reloading/flickering even after my long job finished. Also, in the check reactive I set a variable and when I changed it to another value via an app-widget, it reset to the one that was returned by my previous long job. You can observe that behavior by debugging or simply printing something in the check reactive like this:

```
check <- reactive({
      invalidateLater(millis = 1000, session = session)
      
      if (long_run()$is_alive()) {

        x <- "Job running in background"
      } else {
        x <- "Async job in background completed"
      }
      print("here")
      return(x)
    })
```

The simple solution was to put the `invalideLater` into the if loop. Now everything stops after the long job is finished. Rstudio did some additional linting, when I saved.

Best,
Martin